### PR TITLE
Updated to babel 6.4 dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # babel-preset-es2015-rollup
 
-This is [babel-preset-es2015](http://babeljs.io/docs/plugins/preset-es2015/), minus [modules-commonjs](http://babeljs.io/docs/plugins/transform-es2015-modules-commonjs/), plus [external-helpers-2](http://babeljs.io/docs/plugins/external-helpers/). Use it with [rollup-plugin-babel](https://github.com/rollup/rollup-plugin-babel).
+This is [babel-preset-es2015](http://babeljs.io/docs/plugins/preset-es2015/), minus [modules-commonjs](http://babeljs.io/docs/plugins/transform-es2015-modules-commonjs/), plus [external-helpers](http://babeljs.io/docs/plugins/external-helpers/). Use it with [rollup-plugin-babel](https://github.com/rollup/rollup-plugin-babel).

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "babel-preset-es2015-rollup",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "dependencies": {
-    "babel-plugin-external-helpers-2": "^6.0.15",
-    "babel-preset-es2015": "^6.1.2",
+    "babel-plugin-external-helpers": "^6.4.0",
+    "babel-preset-es2015": "^6.4.0",
     "require-relative": "^0.8.7"
   }
 }


### PR DESCRIPTION
fixes rollup/rollup-plugin-babel#32
