### PR TITLE
Use modify-babel-preset to simplify mutations & versioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # babel-preset-es2015-rollup
 
-This is [babel-preset-es2015](http://babeljs.io/docs/plugins/preset-es2015/), minus [modules-commonjs](http://babeljs.io/docs/plugins/transform-es2015-modules-commonjs/), plus [external-helpers-2](http://babeljs.io/docs/plugins/external-helpers/). Use it with [rollup-plugin-babel](https://github.com/rollup/rollup-plugin-babel).
+This is [babel-preset-es2015](http://babeljs.io/docs/plugins/preset-es2015/), minus [modules-commonjs](http://babeljs.io/docs/plugins/transform-es2015-modules-commonjs/), plus [external-helpers](http://babeljs.io/docs/plugins/external-helpers/). Use it with [rollup-plugin-babel](https://github.com/rollup/rollup-plugin-babel).

--- a/index.js
+++ b/index.js
@@ -1,11 +1,9 @@
-var relative = require( 'require-relative' );
+var modify = require('modify-babel-preset');
 
-var baseLocation = require.resolve( 'babel-preset-es2015' );
-var plugins = require( baseLocation ).plugins.slice();
+module.exports = modify('2015', {
+	// remove commonjs transform
+	'transform-es2015-modules-commonjs': false,
 
-var commonjsPlugin = relative( 'babel-plugin-transform-es2015-modules-commonjs', baseLocation );
-plugins.splice( plugins.indexOf( commonjsPlugin ), 1 );
-
-plugins.push( require( 'babel-plugin-external-helpers-2' ) );
-
-module.exports = { plugins: plugins };
+	// add external helpers
+	'external-helpers': true
+});

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "babel-preset-es2015-rollup",
   "version": "1.0.0",
   "dependencies": {
-    "babel-plugin-external-helpers-2": "^6.0.15",
-    "babel-preset-es2015": "^6.1.2",
-    "require-relative": "^0.8.7"
+    "babel-plugin-external-helpers": "^6.4.0",
+    "babel-preset-es2015": "^6.3.13",
+    "modify-babel-preset": "^1.0.0"
   }
 }


### PR DESCRIPTION
Switch to using `modify-babel-preset` for nice clean overrides to the mainline es2015 preset.

_**Note:** this also incorporates PR #3 to avoid an annoying merge_

I wasn't sure if it would be better to use a `peerDependency` for `babel-preset-es2015`, so for now I've left it as a regular dependency.
