### PR TITLE
Add more metadata to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,5 +5,16 @@
     "babel-plugin-external-helpers": "^6.4.0",
     "babel-preset-es2015": "^6.3.13",
     "modify-babel-preset": "^1.0.0"
+  },
+  "description": "This is [babel-preset-es2015](http://babeljs.io/docs/plugins/preset-es2015/), minus [modules-commonjs](http://babeljs.io/docs/plugins/transform-es2015-modules-commonjs/), plus [external-helpers](http://babeljs.io/docs/plugins/external-helpers/). Use it with [rollup-plugin-babel](https://github.com/rollup/rollup-plugin-babel).",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": "rollup/babel-preset-es2015-rollup",
+  "author": "Rich Harris",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/rollup/babel-preset-es2015-rollup/issues"
   }
 }


### PR DESCRIPTION
FIxing
![image](https://cloud.githubusercontent.com/assets/1404810/12257325/d33a865c-b905-11e5-991e-ebe3ca78c1cd.png)
Also adds a link to this repo

I just ran `npm init` and filled out. Took same license as in `rollup/rollup-plugin-babel`
