### PR TITLE
Workaround for modify-babel-preset relative error

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 var modify = require('modify-babel-preset');
 
-module.exports = modify('es2015', {
+module.exports = modify('babel-preset-es2015', {
 	// remove commonjs transform
 	'transform-es2015-modules-commonjs': false,
 


### PR DESCRIPTION
Currently, if you use babel-preset-es2015-rollup and you call rollup in a different working directory than your node_modules, modify-babel-preset will throw an error.

Specifically, it will throw:

```
Error loading /my-code/index.jsx: Cannot find module 'es2015'
Error: Error loading /my-code/index.jsx: Cannot find module 'es2015'
    at Function.Module._resolveFilename (module.js:440:15)
    at Function.resolve (internal/module.js:27:19)
    at module.exports (/my-code/node_modules/modify-babel-preset/index.js:76:21)
    at Object.<anonymous> (/my-code/node_modules/babel-preset-es2015-rollup/index.js:3:18)
    at Module._compile (module.js:541:32)
    at Object.Module._extensions..js (module.js:550:10)
    at Module.load (module.js:458:32)
    at tryModuleLoad (module.js:417:12)
    at Function.Module._load (module.js:409:3)
    at Module.require (module.js:468:17)
```

After reading the code, I've determined that modify-babel-preset has two routes to find the babel preset from the preset name:

1) If you provide the full name (e.g. `babel-preset-es2015`) as your presetInput, [modify-babel-preset will use require.resolve(presetInput)](https://github.com/developit/modify-babel-preset/blob/master/index.js#L77).

2) If you only provide the postfix (e.g. `es2015`), modify-babel-preset will use a library called relative-resolve and execute [relative.resolve('babel-preset-'+presetInput)](https://github.com/developit/modify-babel-preset/blob/master/index.js#L71). This is the method used in modify-babel-preset's docs.

As babel-preset-2015-rollup only provides the postfix, modify-babel-preset will attempt to use relative-resolve.

However, if [we read relative-resolve's source code](https://github.com/kamicane/require-relative/blob/master/index.js#L11), modify-babel-preset is using relative-resolve the wrong way! relative-resolve expects two parameters: relative.resolve('my-name', 'my-dir'). If 'my-dir' is not provided, relative-resolve will default to process.cwd(). This is why babel-preset-es2015-rollup is failing if you run it in a different working directory.

Therefore, there are two approaches to fixing this:

1) Ask the owners of modify-babel-preset to use relative.resolve('my-name', __dirname). I asked them to do this in a [recent pull request.](https://github.com/developit/modify-babel-preset/pull/12).

However, babel-preset-es2015-rollup still [isn't passing tests for `modify-babel-preset` 3.0.0](https://github.com/rollup/babel-preset-es2015-rollup/pull/12). Even if we wait for that pull request, we'll still have to fix those issues.

2) Simply switch `es2015` to `babel-preset-es2015` here.

Your choice :)
