### PR TITLE
Upgrade to babel 7

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,3 @@
+{
+    "presets": ["@babel/preset-env"]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .DS_Store
 node_modules
+package-lock.json
+yarn.lock

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,4 @@
+.DS_Store
+node_modules
+.*
+/test.js

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,3 @@ language: node_js
 node_js:
   - "stable"
   - "6"
-  - "4"

--- a/index.js
+++ b/index.js
@@ -1,18 +1,10 @@
-var relative = require( 'require-relative' );
+module.exports = function(api) {
+	api.assertVersion(7);
 
-var baseLocation = require.resolve( 'babel-preset-es2015' );
-var plugins = require( baseLocation ).plugins.slice();
-
-var commonjsPlugin = relative( 'babel-plugin-transform-es2015-modules-commonjs', baseLocation );
-
-var i = plugins.length;
-while ( i-- ) {
-	var plugin = plugins[i];
-	if ( plugin === commonjsPlugin || plugin[0] === commonjsPlugin ) {
-		plugins.splice( i, 1 );
-	}
+	return { 
+		presets: [
+			[require('@babel/preset-env'), { modules: false }]
+		],
+		plugins: [require( '@babel/plugin-external-helpers' )]
+	 };
 }
-
-plugins.push( require( 'babel-plugin-external-helpers' ) );
-
-module.exports = { plugins: plugins };

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "description": "This is [babel-preset-es2015](http://babeljs.io/docs/plugins/preset-es2015/), minus [modules-commonjs](http://babeljs.io/docs/plugins/transform-es2015-modules-commonjs/), plus [external-helpers](http://babeljs.io/docs/plugins/external-helpers/). Use it with [rollup-plugin-babel](https://github.com/rollup/rollup-plugin-babel).",
   "main": "index.js",
   "scripts": {
-    "test": "mocha"
+    "test": "mocha --require @babel/register"
   },
   "repository": "rollup/babel-preset-es2015-rollup",
   "author": "Rich Harris",
@@ -22,6 +22,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.0.0",
+    "@babel/register": "^7.0.0",
     "mocha": "^3.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,9 +1,12 @@
 {
   "name": "babel-preset-es2015-rollup",
   "version": "3.0.0",
+  "peerDependencies": {
+    "@babel/core": "^7.0.0"
+  },
   "dependencies": {
-    "babel-plugin-external-helpers": "^6.18.0",
-    "babel-preset-es2015": "^6.3.13",
+    "@babel/plugin-external-helpers": "^7.0.0",
+    "@babel/preset-env": "^7.0.0",
     "require-relative": "^0.8.7"
   },
   "description": "This is [babel-preset-es2015](http://babeljs.io/docs/plugins/preset-es2015/), minus [modules-commonjs](http://babeljs.io/docs/plugins/transform-es2015-modules-commonjs/), plus [external-helpers](http://babeljs.io/docs/plugins/external-helpers/). Use it with [rollup-plugin-babel](https://github.com/rollup/rollup-plugin-babel).",
@@ -18,7 +21,7 @@
     "url": "https://github.com/rollup/babel-preset-es2015-rollup/issues"
   },
   "devDependencies": {
-    "babel-core": "^6.13.2",
+    "@babel/core": "^7.0.0",
     "mocha": "^3.0.2"
   }
 }

--- a/test.js
+++ b/test.js
@@ -1,4 +1,4 @@
-var transform = require('babel-core').transform;
+var transform = require('@babel/core').transform;
 var strictEqual = require('assert').strictEqual;
 var babelPresetEs2015Rollup = require('./');
 

--- a/test.js
+++ b/test.js
@@ -1,6 +1,6 @@
-var transform = require('@babel/core').transform;
-var strictEqual = require('assert').strictEqual;
-var babelPresetEs2015Rollup = require('./');
+import { transform } from '@babel/core';
+import { strictEqual } from 'assert';
+import babelPresetEs2015Rollup from './';
 
 describe('babel-preset-es2015-rollup', function() {
   it('transforms ES2015 features that are not modules', function() {


### PR DESCRIPTION
- Update all `babel` dependencies
- Drop support for `node@<6` since `babel` no longer supports them
- Use `@babel/register` on `test.js`
- Use `modules: false` on `@babel/preset-env` instead of splicing out the modules transform
- Add a `.npmignore` since unnecessary files like `.travis.yml` and `test.js` are included in the current package